### PR TITLE
rpm spec: Add explicit php requirements

### DIFF
--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -10,6 +10,7 @@ Source0: https://github.com/sonicle-webtop/z-push-webtop/archive/wt-%{wtrelease}
 BuildArch: noarch
 
 Requires: webtop5-core
+Requires: php-process, php-pgsql, php-imap, php-ldap, php-mcrypt, php-mbstring
 Conflicts: webtop4-zpush
 
 BuildRequires: php-cli


### PR DESCRIPTION
The php requirements were previously installed by nethserver-webtop5
package
NethServer/dev#5666