### PR TITLE
Switch to new webtop-eas-server implementation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,13 @@
+{
+  "timezone": "Etc/UTC",
+  "log": {
+    "level": "DEBUG",
+    "dir": "/var/log/z-push/"
+  },
+  "webtop": {
+    "apiBaseUrl": "http://localhost:58080/webtop"
+  },
+  "state": {
+      "dir": "/var/log/z-push/state"
+   }
+}

--- a/webtop-zpush
+++ b/webtop-zpush
@@ -1,0 +1,5 @@
+/var/log/z-push/*.log {
+    copytruncate
+    missingok
+    create 0644 apache apache
+}

--- a/webtop5-zpush.conf
+++ b/webtop5-zpush.conf
@@ -2,7 +2,7 @@ Alias /Microsoft-Server-ActiveSync /usr/share/webtop/z-push/index.php
 
 <Directory "/usr/share/webtop/z-push/">
    <FilesMatch \.php$>
-        SetHandler "proxy:fcgi://127.0.0.1:9001"
+        SetHandler "proxy:fcgi://127.0.0.1:9002"
     </FilesMatch>
 
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1

--- a/webtop5-zpush.conf
+++ b/webtop5-zpush.conf
@@ -1,0 +1,13 @@
+Alias /Microsoft-Server-ActiveSync /usr/share/webtop/z-push/index.php
+
+<Directory "/usr/share/webtop/z-push/">
+   <FilesMatch \.php$>
+        SetHandler "proxy:fcgi://127.0.0.1:9001"
+    </FilesMatch>
+
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>

--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -1,4 +1,4 @@
-%define wtrelease 5.3.0.1
+%define wtrelease 5.6.1
 
 Summary: WebTop z-push
 Name: webtop5-zpush
@@ -6,27 +6,29 @@ Version: 1.1.6
 Release: 1%{?dist}
 License: GPL
 URL: %{url_prefix}/%{name}
-Source0: https://github.com/sonicle-webtop/z-push-webtop/archive/wt-%{wtrelease}.tar.gz
+Source0: https://github.com/sonicle-webtop/webtop-eas-server/archive/wt-%{wtrelease}.tar.gz
+Source1: webtop5-zpush.conf
+Source2: config.json
+Source3: webtop-zpush
 BuildArch: noarch
 
 Requires: webtop5-core
-Requires: php-process, php-pgsql, php-imap, php-ldap, php-mcrypt, php-mbstring
+Requires: rh-php71-php-fpm, rh-php71-php-mbstring, rh-php71-php-imap
 Conflicts: webtop4-zpush
-
-BuildRequires: php-cli
 
 %description
 NethServer z-push for WebTop 5
 
-%prep
-#%setup
-
 %build
 mkdir -p root/var/log/z-push/state
 mkdir -p root/usr/share/webtop/z-push/
-tar xvzf %{SOURCE0} --exclude='.gitignore' -C root/usr/share/webtop/z-push --strip-components=2 z-push-webtop-wt-%{wtrelease}/src
-rm -rf  root/usr/share/webtop/z-push/backend/{caldav,carddav,kopano,ldap,maildir,searchldap,sqlstatemachine,vcarddir}
-php -r "include('root/usr/share/webtop/z-push/backend/webtop/config.php'); file_put_contents('root/usr/share/webtop/z-push/VERSION',ZPUSH_VERSION);"
+mkdir -p root/etc/httpd/conf.d/
+mkdir -p root/etc/logrotate.d/
+tar xvzf %{SOURCE0} --exclude='.gitignore' -C root/usr/share/webtop/z-push --strip-components=2 webtop-eas-server-wt-%{wtrelease}/src
+cp %{SOURCE1} root/etc/httpd/conf.d/
+cp %{SOURCE2} root/usr/share/webtop/z-push/
+cp %{SOURCE3} root/etc/logrotate.d/
+echo %{wtrelease} > VERSION
 
 %install
 rm -rf %{buildroot}
@@ -38,7 +40,13 @@ rm -rf %{buildroot}
 %attr(755, apache, apache) /var/log/z-push
 %attr(755, apache, apache) /var/log/z-push/state
 %attr(755, root, root) /usr/share/webtop/z-push/z-push-admin.php
+%config /etc/httpd/conf.d/webtop5-zpush.conf
+%config /usr/share/webtop/z-push/config.json
 /usr/share/webtop/z-push/*
+/usr/share/webtop/z-push/.htaccess
+/etc/logrotate.d/webtop-zpush
+%doc VERSION
+
 
 %changelog
 * Tue Jun 25 2019 Matteo Valentini <matteo.valentini@nethesis.it> - 1.1.6-1

--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -1,4 +1,4 @@
-%define wtrelease 5.7.0
+%define wtrelease 5.7.2
 
 Summary: WebTop z-push
 Name: webtop5-zpush

--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -13,7 +13,7 @@ Source3: webtop-zpush
 BuildArch: noarch
 
 Requires: webtop5-core
-Requires: rh-php71-php-fpm, rh-php71-php-mbstring, rh-php71-php-imap, rh-php71-php-pdo
+Requires: rh-php72-php-fpm, rh-php72-php-mbstring, rh-php72-php-imap, rh-php72-php-pdo
 Conflicts: webtop4-zpush
 
 %description

--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -1,4 +1,4 @@
-%define wtrelease 5.6.4
+%define wtrelease 5.7.0
 
 Summary: WebTop z-push
 Name: webtop5-zpush

--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -13,7 +13,7 @@ Source3: webtop-zpush
 BuildArch: noarch
 
 Requires: webtop5-core
-Requires: rh-php71-php-fpm, rh-php71-php-mbstring, rh-php71-php-imap
+Requires: rh-php71-php-fpm, rh-php71-php-mbstring, rh-php71-php-imap, rh-php71-php-pdo
 Conflicts: webtop4-zpush
 
 %description

--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -1,4 +1,4 @@
-%define wtrelease 5.6.1
+%define wtrelease 5.6.4
 
 Summary: WebTop z-push
 Name: webtop5-zpush

--- a/webtop5-zpush.spec
+++ b/webtop5-zpush.spec
@@ -1,4 +1,4 @@
-%define wtrelease 5.7.2
+%define wtrelease 5.7.3
 
 Summary: WebTop z-push
 Name: webtop5-zpush


### PR DESCRIPTION
Old changes:

- Switch to PHP 71
- Uniform spec to webtop5-webdav
- Add logrotate

To do:

- [x] Switch to PHP 7.2
- [x] Upgrade to latest [upstream release](https://github.com/sonicle-webtop/webtop-eas-server/releases/tag/wt-5.7.2)

NethServer/dev#5732

